### PR TITLE
Retranslated and improved

### DIFF
--- a/eula/it.html
+++ b/eula/it.html
@@ -20,7 +20,7 @@ body {
 </p>
 <p class="cjk" align="CENTER">
 Ultimo
-aggiornamento: 2016/12/04</p>
+aggiornamento: 2018/9/5</p>
 <p>
 <br>
 </p>
@@ -30,7 +30,7 @@ aggiornamento: 2016/12/04</p>
 <b>Questo
 è un accordo RiiConnect24</b><br>
 <br>
-<b>Questo accordo è per l'utilizzo di RiiConnect24, un servizio sostitutivo di Wiiconnect24, cosí come servizi che forniamo tramite il nostro DNS (come Wiimmfi) </b>
+<b>Questo accordo è per l'utilizzo di RiiConnect24, un servizio sostitutivo di Wiiconnect24, cosí come dei servizi che forniamo tramite il nostro DNS (come Wiimmfi) </b>
 </p>
 <p class="cjk" align="CENTER">
 <br>
@@ -40,14 +40,13 @@ aggiornamento: 2016/12/04</p>
 clic sul pulsante "Accetto" se si accettano questi termini</b></p>
 <p class="cjk" align="CENTER">
 <b>Fare
-clic sul pulsante "Non accetto" se non si accettano
-<span style="font-style:italic;">non</span> i termini di questo accordo. Tuttavia, questa scelta fermerà l'accesso dell'utente al Canale Wii Shop e a RiiConnect24.</b></p>
+clic sul pulsante "Non accetto" se <i>non</i> si accettano i termini di questo accordo. Tuttavia, questa scelta impedirà l'accesso al Canale Wii Shop e a RiiConnect24.</b></p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-<b>Questo
-è un accordo tra voi e gli sviluppatori di Riiconnect24, proprio come i servizi accessibili attraverso i DNS (cioè Wiimmfi) Wiimmfi sara` indicato come "Wiimmfi", oppure "Wiimmfi WFC",
+<b>Questo è un accordo tra voi e gli sviluppatori di Riiconnect24, come pure tra voi ed i servizi accessibili attraverso i DNS (cioè Wiimmfi).
+Wiimmfi sara` indicato come "Wiimmfi", oppure "Wiimmfi WFC",
 e RiiConnect24 sarà indicato come "RiiConnect24" o "RC24". </b>
 </p>
 <p class="cjk">
@@ -57,105 +56,81 @@ e RiiConnect24 sarà indicato come "RiiConnect24" o "RC24". </b>
 <b>Servizi online di Nintendo. </b>
 </p>
 <p class="cjk">
+<i>I seguenti due articoli disciplinano l'utilizzo del canale Wii Shop.</i>
 <br>
 </p>
 <p class="cjk">
-Articolo
-1: <u>Roba legale reale da Nintendo</u></p>
+Articolo 1: <u>Roba legale reale da Nintendo</u></p>
 <p class="cjk">
-Questo
-accordo disciplina l'utilizzo del canale Wii Shop.
-</p>
-<p class="cjk">
-A seguito
-i termini del presente accordo e, se del caso,
-l'accordo di servizio Canale Wii Shop, questo accordo
-include anche i seguenti documenti:</p>
+In aggiunta a questa intera pagina, questo accordo include anche i seguenti documenti:</p>
 <ul>
 	<li><p class="cjk">
-	Il
-	Wii Servizi di rete Codice di condotta. Lo scopo di questo documento
-	è quello di mantenere i servizi Internet Wii un ambiente sicuro e affidabile</p>
+	Il Codice di condotta dei servizi online Wii.
+	Lo scopo di tale documento è quello di mantenere i servizi Internet Wii un ambiente sicuro e affidabile.</p>
 	</li><li><p class="cjk">
-	La
-	Privacy Policy servizi Internet Wii. Questo documento fornisce una comprensione delle
-	informazioni che viene inviato e raccolte attraverso i servizi Internet Wii.
+	La Privacy Policy dei servizi internet Wii. Questo documento fornisce una spiegazione delle
+	informazioni che vengono raccolte ed inviate attraverso i servizi Internet Wii.
 	</p>
 </li></ul>
 <p class="cjk">
-Si
-consiglia vivamente di rivedere entrambi questi documenti prima di accettare i termini di questo accordo.
+Si consiglia vivamente di rivedere entrambi questi documenti prima di accettare i termini di questo accordo.
 Le versioni complete di questi documenti sono disponibili presso http://wii.nintendo-europe.com/terms.</p>
 <p class="cjk">
 Accettando
-i termini del contratto di servizi Internet Wii,
-si sta anche incondizionata accettazione di tutte le condizioni di questi documenti.</p>
+i termini dell'accordo di RiiConnect24,
+si sta dichiarando anche l'incondizionata accettazione di tutte le condizioni di questi documenti.</p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-2: <u>Concessione di licenza</u></p>
+Articolo 2: <u>Concessione di licenza</u></p>
 <p class="cjk">
-Vi
-concediamo una, limitata, non esclusiva,
-revocabile personali per utilizzare i servizi Internet Wii,
-in conformità al presente accordo.
+Nintendo concede una licenza limitata, non esclusiva,
+revocabile e personale per utilizzare i servizi Internet Wii,
+in conformità agli articoli sopra citati.
 In particolare:</p>
 <ul>
 	<li><p class="cjk">
-	I
-	servizi Internet Wii è esclusivamente per il proprio uso ricreativo personale.
-	Tuttavia, siete responsabili per l'uso e per l'uso da parte di altri servizi Internet Wii tramite la console Wii,
-	anche se non si dà loro il permesso di farlo.
+	I servizi Internet Wii sono intesi esclusivamente per l'uso ricreativo personale.
+	Tuttavia, si è responsabili per l'uso fatto da qualsiasi persona dei servizi Internet Wii tramite questa console Wii, anche se non si dà ad esse il permesso di farlo.
 	</p>
 	</li><li><p class="cjk">
-	L'utente
-	non può trasferire o assegnare questa licenza ad un'altra persona o entità,
+	L'utente non può trasferire o assegnare questa licenza ad un'altra persona o entità,
 	e ogni tentativo di trasferimento o cessione della licenza saranno annullate.
 	</p>
 	</li><li><p class="cjk">
-	E 'vietato utilizzare o tentare di utilizzare i servizi Internet Wii a scopo commerciale o illegale,
+	È vietato utilizzare o tentare di utilizzare i servizi Internet Wii a scopo commerciale o illegale,
 	o in un modo che possa danneggiare altre persone o società,
 	o in maniera non autorizzata o in altro modo improprio come si può specificare di volta in volta. </p>
 	</li><li><p class="cjk">
-    L'utente
-	è responsabile per la cancellazione tutti i Contenuti,
-	inclusi giochi e altri software scaricati tramite il Canale Wii Shop, ei dati personali,
-	e tutte le altre informazioni sensibili memorizzate che è residente sulla tua console Wii prima di vendere o comunque trasferire il tuo Wii a terzi partito.
-	Se si acquista una console Wii usato, si è anche responsabile per la cancellazione di tutti i Contenuti, i dati personali,
-	e tutte le altre informazioni sensibili memorizzate che possono essere presente nella suddetta console Wii al momento lo si acquista.</p>
+    L'utente è responsabile per la cancellazione di tutti i Contenuti (inclusi giochi e altri software scaricati tramite il Canale Wii Shop), dei dati personali,
+	e di tutte le altre informazioni sensibili eventualmente memorizzate sulla console Wii prima di venderla o comunque trasferirla a terzi parti.
+	Se si acquista una console Wii usata, il nuovo proprietario è altrettanto responsabile per la cancellazione di tutti i Contenuti, dati personali,
+	e tutte le altre informazioni sensibili memorizzate che possono essere presenti nella suddetta console Wii al momento lo si acquista.</p>
 </li></ul>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-<b>RiiConnect24
-</b>
+<b>RiiConnect24</b>
 </p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-3: <u>RiiConnect24</u></p>
+Articolo 3: <u>RiiConnect24</u></p>
 <p class="cjk">
-Con
-l'iscrizione per i servizi Internet Wii, RiiConnect24 e Wiimmfi, l'utente accetta che possiamo fornire servizi con RiiConnect24 e Wiimmfi.
-Alcuni di questi possono essere forniti tramite collegamento in standby.
+Accettando l'uso dei servizi Internet Wii, RiiConnect24 e Wiimmfi, l'utente accetta che possiamo fornire i servizi di RiiConnect24 e Wiimmfi.
+Alcuni di questi possono essere forniti tramite connessione in standby.
 </p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-4: <u>Aggiornamenti e modifiche</u></p>
+Articolo 4: <u>Aggiornamenti e modifiche</u></p>
 <p class="cjk">
-I proprietari
-di RiiConnect24 e Wiimmfi possono aggiornare (Difficoltà)
-qualsiasi software distribuito tramite RiiConnect24 o modificare
-il contenuto di Internet di RiiConnect24, totale o parziale,
-in qualsiasi momento. Tuttavia, tale aggiornamento o modifica sarà
+I proprietari di RiiConnect24 e Wiimmfi possono aggiornare qualsiasi software distribuito tramite RiiConnect24, nonchè modificare i contenuti online accessibili tramite RiiConnect24, in maniera totale o parziale, in qualsiasi momento.
+Tuttavia, qualsiasi tale aggiornamento o modifica sarà
 a beneficio degli utenti di Wiimmfi e di RiiConnect24.</p>
 <p class="cjk">
 <br>
@@ -166,23 +141,18 @@ a beneficio degli utenti di Wiimmfi e di RiiConnect24.</p>
 <br>
 </p>
 <p class="cjk">
-Articolo
-5: <u>Fornitori terzi</u></p>
+Articolo 5: <u>Fornitori terzi</u></p>
 <p class="cjk">
-RiiConnect24
-permette la connessione iniziale a Wiimmfi.</p>
+RiiConnect24 permette la connessione iniziale a Wiimmfi.</p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-6: <u>Proprietà Intellettuale</u></p>
+Articolo 6: <u>Proprietà Intellettuale</u></p>
 <p class="cjk">
-Tutti i
-server RiiConnect24 sono basati su dump di legittima WiiConnect24; in tal modo, tutti i patcher, creatori di contenuti, e gli script sono © RiiConnect24 2015- [Anno corrente]
+Tutti i server RiiConnect24 sono basati sul reverse engineering di dump dell'originale WiiConnect24. Tutti i patcher, i creatori di contenuti, e gli script sono © RiiConnect24 2015-<date class="current-year">2018</date>
 </p><p class="cjk">
-Wiimmfi,
-tuttavia, è basato sul proprio codice, ed è quindi © Dirk "Wiimm" Clemens e Florian "Leseratte" Bach, 2014- [Anno corrente]
+Wiimmfi, tuttavia, è basato sul proprio codice, che è quindi © Dirk "Wiimm" Clemens e Florian "Leseratte" Bach, 2014-<date class="current-year">2018</date>
 <br>
 </p>
 <p class="cjk">
@@ -195,29 +165,24 @@ tuttavia, è basato sul proprio codice, ed è quindi © Dirk "Wiimm" Clemens e F
 <br>
 </p>
 <p class="cjk">
-Articolo
-8: <u>Inseriti</u></p>
+Articolo 8: <u>Suggerimenti e richieste</u></p>
 <p class="cjk">
-Si prega
-di darci suggerimenti per lo sviluppo di RiiConnect24; tuttavia si prega di notare alcuni suggerimenti potrebbero non essere attuabili.
+Accettiamo volentieri suggerimenti per lo sviluppo di RiiConnect24; tuttavia si prega di notare che non tutti i  suggerimenti potrebbero essere attuabili.
 </p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-9: <u>Protezione dei dati personali</u></p>
+Articolo 9: <u>Protezione dei dati personali</u></p>
 <ul>
 	<li><p class="cjk">
-	Come
-	parte del servizio di RiiConnect24, ora forniamo accesso a un sistema WiiConnect24 Mail.
-	Tuttavia, si ricorda che siamo in grado di accedere alla posta
-	- potremmo solo fare questo se riferito da un altro utente. Tuttavia,
-	se qualcuno ti sta inviando posta inappropiata,
-	si prega di rimuoverli dalla lista amici prima di preoccuparsi RiiConnect24;
-	non possono inviare la posta se il vostro Wii dice di no.
-	Inoltre, siamo in grado di influenzare direttamente il vostro elenco di amici in qualsiasi modo,
-	o forma.
+	Come parte del servizio di RiiConnect24, ora forniamo accesso al sistema di messaggistica WiiConnect24.
+	Tuttavia, si ricorda che siamo tecnicamente in grado di accedere alla posta scambiata tramite il servizio
+	- anche se ci impegneremo a fare questo solo in caso di segnalazioni da un altro utente.
+	Se qualcuno ti sta inviando posta inappropiata,
+	raccomandiamo di rimuoverli dalla lista amici (Rubrica Wii) prima di segnalarlo allo staff di RiiConnect24;
+	non possono inviarvi messaggi se il vostro Wii dice di no.
+	Inoltre, non siamo in grado di influenzare direttamente la vostra lista di amici in qualsiasi modo o forma.
 	</p>
 </li></ul>
 <p class="cjk">
@@ -227,33 +192,24 @@ Articolo
 <br>
 </p>
 <p class="cjk">
-Articolo
-10: <u>Accordo Aggiornamenti</u></p>
+Articolo 10: <u>Aggiornamenti di questo accordo</u></p>
 <p class="cjk">
-Wiimmfi e RiiConnect24
-possono modificare i termini e le condizioni del presente contratto,
-compreso il Codice di Condotta dei servizi Wii e l'Informativa
-sulla privacy politica per servizi Internet Wii sono entrambi
-una parte di questo accordo, e in qualsiasi momento, in misura sara`
-necessario o utile per migliorare il servizio o per adattarlo in modo da riflettere
-i cambiamenti dei requisiti tecnici o legali.
+Nintendo, Wiimmfi e RiiConnect24 possono modificare i termini e le condizioni del presente contratto
+(compreso il Codice di Condotta dei servizi internet Wii e l'Informativa sulla privacy dei servizi internet Wii, che sono entrambi parte integrante di questo accordo)
+in qualsiasi momento, per quanto si riveli necessario o utile per migliorare il servizio o per adattarlo in modo da riflettere i cambiamenti dei requisiti tecnici o legali.
 </p>
 <p class="cjk">
-Una
-versione aggiornata di questo accordo sarà sempre disponibile su
-Internet all'indirizzo https://rc24.xyz/eula/it.html
-Pubblicheremo un messaggio sulla Bacheca Wii che informa su una modifica a questo accordo,
-almeno 5 giorni prima del cambiamento diventi ufficiale.
+Una versione aggiornata di questo accordo sarà sempre disponibile su Internet all'indirizzo https://rc24.xyz/eula/it.html .
+Pubblicheremo un messaggio sulla Bacheca Wii che informi su un'eventuale modifica a questo accordo,
+almeno 5 giorni prima che il cambiamento diventi ufficiale.
 </p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-11: <u>Divieto di cessione</u></p>
+Articolo 11: <u>Divieto di cessione</u></p>
 <p class="cjk">
-L'utente
-è responsabile per l'utilizzo della console Wii e dei servizi Internet Wii da amici e parenti.
+L'utente è responsabile per l'utilizzo della propria console Wii e dei servizi Internet Wii da parte di amici, parenti, e terze parti in genere.
 L'utente non può cedere il presente contratto a terzi.
 </p>
 <p class="cjk">
@@ -263,64 +219,55 @@ L'utente non può cedere il presente contratto a terzi.
 <br>
 </p>
 <p class="cjk">
-Articolo
-12: <u>Interpretazione dell'accordo</u>
+Articolo 12: <u>Interpretazione dell'accordo</u>
 </p>
 <p class="cjk">
-Se una qualsiasi parte del presente accordo è ritenuta non valida o non applicabile,
-quella parte del contratto non sarà più applicabile. Lei accetta inoltre che possiamo
-sostituire la parte non valida da una disposizione che riflette o si avvicina a riflettere
-l'intenzione iniziale.
+Se una qualsiasi parte del presente accordo è ritenuta non valida o non applicabile, quella parte del contratto non sarà più applicabile.
+L'utente accetta che l'eliminazione di una parte dell'accordo non influenza la validità delle altre.
+L'utente accetta inoltre che la parte non valida possa essere sostituita da una disposizione che rifletta o più si avvicini a riflettere l'intenzione iniziale.
 </p>
 <p class="cjk">
 <br>
 </p>
 <p class="cjk">
-Articolo
-13: <u>Definizioni</u></p>
+Articolo 13: <u>Definizioni</u></p>
 <p>
-"Contenuto"
-si intende il software e contenuti, comprese le applicazioni denominate "Canali",
+Per "Contenuto" si intende il software e contenuti in genere, comprese le applicazioni denominate "Canali",
 che Nintendo possiede, o ha ottenuto il diritto di utilizzare, distribuire o concedere in licenza,
-e che è disponibile per il download attraverso il Servizio Canale Wii Shop, o attraverso altri mezzi.</p>
+e distribuisce attraverso il Servizio Canale Wii Shop, o attraverso altri mezzi.</p>
 <p>
-"Wiimmfi"
-è un server personalizzato progettato per sostituire la Nintendo WFC, che è stato sviluppato da Leseratte e Wiimm.
+"Wiimmfi" è un server personalizzato progettato per sostituire la Nintendo WFC, che è stato sviluppato da Leseratte e Wiimm.
 </p>
 <p>
- "Nintendo proprietà intellettuale"
- si intendono tutte le proprietà intellettuali associate con la console Wii e la Wii di rete,
- compreso ma non limitato a marchi, marchi di servizio, loghi, disegni, diritti d'autore,
- invenzioni, brevetti, segreti commerciali, know-how e altre riservate e informazioni proprietarie
- che Nintendo ha sviluppato, possiede o è concessa una licenza per l'uso.
+ Per "proprietà intellettuale di Nintendo" si intendono tutte le proprietà intellettuali associate con la console Wii ed i servizi internet Wii
+ (comprendenti ma non limitate a: marchi, loghi, disegni, diritti d'autore, invenzioni, brevetti, segreti commerciali, know-how e altre informazioni riservate e proprietarie
+ che Nintendo ha sviluppato, possiede od abbia avuto in concessione una licenza per l'uso).
 </p>
 <p>
-"Wii Points"
-si intendono i punti che si acquista da Nintendo tramite il servizio Canale Wii Shop o
-tramite Wii Points Cards e che possono essere utilizzati da voi in cambio di una licenza per
-utilizzare il contenuto o per l'acquisto di prodotti.</p>
+Con "Wii Points" si intendono i punti (credito) che in passato si è potuto acquistare da Nintendo tramite il servizio Canale Wii Shop o
+tramite Wii Point Cards e Nintendo Point Cards, e che possono essere utilizzati da voi (fino al 30 gennaio 2019) in cambio di una licenza per
+utilizzare Contenuti o per l'acquisto di Prodotti.</p>
 <p>
-"Prodotti"
-si intendono i beni diversi dai contenuti che vengono resi disponibili per
-l'acquisto tramite il servizio Canale Wii Shop.
+Per "Prodotti" si intendono i beni diversi dai Contenuti che vengono resi disponibili per l'acquisto tramite il servizio Canale Wii Shop.
 </p>
 <p class="cjk">
-"RiiConnect24" indica il servizio grazie al quale RiiConnect24 può distribuire il software, materiale, e-mail e altri dati alla console Wii, e il Forum della console Wii, in qualsiasi momento e per cui è possibile inviare e ricevere e-mail, fotografie e altro materiale con la console Wii.</p>
+"RiiConnect24" indica il servizio grazie al quale RiiConnect24 può distribuire software, materiale, e-mail e altri dati alla console Wii in qualsiasi momento, e grazie al quale è possibile inviare e ricevere e-mail, fotografie e altro materiale con la console Wii.</p>
 <p class="cjk">
 "Console Wii" indica il sistema di Nintendo ha venduto e commercializzato da Nintendo con il marchio Wii, compresi eventuali sistemi successivi e sistemi compatibili.</p>
 <p>
-"Servizi Internet Wii" indica il negozio di servizio Wii Channel, WiiConnect24, e tutti i servizi correlati e materiale consegnato alla tua console Wii su Internet, incluso ma non limitato a contenuti, prodotti e Wii Points.</p>
+"Servizi Internet Wii" indica il servizio Canale Wii Shop, e tutti i prodotti e servizi correlati consegnati alla tua console Wii attraverso internet (comprendenti ma non limitati a: Contenuti, Prodotti, e Wii Points).</p>
 <p>
-"Servizi Internet Wii Codice di condotta": il codice di condotta applicabile ai servizi Internet Wii come rivisto da noi di volta in volta, una versione corrente di che sarà sempre disponibile presso http://wii.nintendo-europe.com/terms</p>
+"Codice di condotta dei Servizi Internet Wii": il codice di condotta applicabile ai servizi Internet Wii come rivisto da Nintendo di volta in volta; una versione corrente di esso sarà sempre disponibile presso http://wii.nintendo-europe.com/terms</p>
 <p>
-"Servizi Internet Wii Privacy Policy" si intende la privacy policy applicabile ai servizi Internet Wii come rivisto da noi di volta in volta, una versione corrente di che sarà sempre disponibile presso http://wii.nintendo-europe.com/terms</p>
+"Informativa sulla privacy dei Servizi Internet Wii": la privacy policy applicabile ai servizi Internet Wii come rivists da Nintendo di volta in volta; una versione corrente di esss sarà sempre disponibile presso http://wii.nintendo-europe.com/terms</p>
 <p>
-"Wii Points Card" significa carte prepagate venduti o distribuiti da Nintendo o Nintendo di partner promozionali che contengono crediti per Wii Points.</p>
+Le "Wii Points Card" e le "Nintendo Points Card" sono carte prepagate monouso, vendute o distribuiti da Nintendo o da partner di Nintendo, che contengono crediti per Wii Points.
+Esse non sono più valide dal 26 marzo 2018.</p>
 <p>
-"Wii Shop account del Canale" indica un conto personale e non trasferibile che verrà stabilito sulla tua console Wii con l'accettazione di questi termini e le condizioni Wii Shop Channel Service di utilizzo, e che si utilizzano in connessione con il servizio Canale Wii Shop.
+"Account del Canale Wii Shop" indica un account personale e non trasferibile che verrà stabilito sulla tua console Wii con l'accettazione del Codice di condotta e dell'Informativa sulla privacy dei servizi internet Wii seguita dall'utilizzo del Canale Wii Shop; tale account viene utilizzato dal  servizio Canale Wii Shop.
 </p>
 <p>
-"Servizio Canale Wii Shop" si intendono i servizi relativi al Conto Canale Wii Shop, Wii Points, i prodotti, il negozio online, e il servizio di download, ognuno dei quali Nintendo, direttamente o indirettamente opera, come indicato in questo accordo.
+Con "Servizio Canale Wii Shop" si intendono i servizi relativi all'account Canale Wii Shop, ai Wii Points, ai Prodotti, il negozio online, e il servizio di download, ognuno dei quali Nintendo, direttamente o indirettamente opera, come indicato in questo accordo.
 </p>
 <hr><br>
 <p></p>
@@ -344,29 +291,30 @@ Il presente Codice di Comportamento Wiimmfi ( "Codice di Comportamento Wii") del
 <br>
 </p>
 <p class="cjk">
-1. L'utilizzo del Wiimmfi è soggetto al presente Codice di Comportamento Wii, che vieta qualsiasi comportamento dannoso, illegale o altrimenti offensivo, tra cui, ma non limitato a quanto segue:</p>
+1. L'utilizzo del Wiimmfi è soggetto al presente Codice di Comportamento Wii, che vieta qualsiasi comportamento dannoso, illegale o altrimenti offensivo; questa definizione comprende, ma non è limitata, a quanto segue:</p>
 <ul>
 	<li><p class="cjk">
-	Falsa luce, spacciarsi, abusare, molestare, minacciare o molestare qualsiasi persona o società, tra cui, ma non solo ad altri utenti, Wiimmfi stesso, e / oi suoi moderatori.
+	Porre in falsa luce, spacciarsi, abusare, minacciare o molestare qualsiasi persona o società, ad esempio altri utenti, il servizio Wiimmfi stesso, e/o i suoi moderatori.
 	</p>
 	</li><li><p class="cjk">
-	Fare qualsiasi attività illegale, discriminatoria, diffamatoria, offensive, moleste, abusivi, osceni, minacciosi, fisicamente pericoloso o altrimenti deplorevole in connessione con Wiimmfi. </p>
+	Compiere qualsiasi attività illegale, discriminatoria, diffamatoria, offensiva, molesta, abusiva, oscena, minacciosa, fisicamente pericolosa o altrimenti deplorevole in connessione o associazione con Wiimmfi. </p>
 </li></ul>
 <p class="cjk">
-2. Wiimmfi & RiiConnect24 non sono responsabili per qualsiasi cosa tu dica o qualsiasi cosa che accade su Wiimmfi o RiiConnect24 come risultato del suo uso dei servizi stessi; solamente tu sei responsabile.</p>
+2. Wiimmfi e RiiConnect24 non sono responsabili per qualsiasi cosa venga detta o avvenga su Wiimmfi o RiiConnect24 come conseguenza dell'uso dei servizi stessi; solamente l'utente ne è responsabile.</p>
 <p class="cjk">
-3. Virtuale. Alcuni giochi o altri contenuti possono avere alcune caratteristiche che possono essere scambiati con altri utenti Wii Network Services. Ad esempio, un gioco potrebbe dare la possibilità di creare un personaggio che raccoglie gli oggetti (come una macchina o di monete d'oro) e presenta alcune caratteristiche (come un'abilità speciale o aspetto). Queste caratteristiche sono a volte chiamati "proprietà virtuale". Nintendo (o dei suoi licenziatari) possiede questa proprietà virtuale, e non si può vendere, scambiare, cedere, concedere in licenza o altrimenti trasmettere proprietà virtuale con soldi veri o per Wii Points.
+3. Commercio di proprietà virtuale. Alcuni giochi o altri contenuti possono avere alcune caratteristiche od elementi che possono essere scambiati con altri utenti dei servizi internet Wii. [Ad esempio, un gioco potrebbe dare la possibilità di creare un personaggio che raccoglie gli oggetti (come una macchina o di monete d'oro) e presenta alcune caratteristiche (come un'abilità speciale o aspetto). Queste caratteristiche sono a volte chiamati "proprietà virtuale"]. Nintendo (o i suoi licenziatari) possiedono questa proprietà virtuale, e non è consentito vendere, scambiare, cedere, concedere in licenza o altrimenti trasmettere proprietà virtuale in cambio di soldi veri o di Wii Points.
 </p>
 <p class="cjk">
-4. Regole di Wiimmfi. Wiimmfi ha regole che sono progettati per rendere una famiglia ambiente amichevole e senza baro. Ecco le regole:
-<br></p><li>Non utilizzare le applicazioni che cambiano il ID della console
-<br></li><li>Non trucchi che si avvantaggiano (hack VR, trucchi voce, modificatori di velocità, hack texture), sono ammessi quando in tutto il mondo. loro sono, comunque ammessi regione 191 camere e tuoi amici camere, <b>se l'host permette loro.</b>
+4. Regole di Wiimmfi. Wiimmfi ha regole che sono progettati per renderlo un ambiente adatto a tutte le età e senza baro. Ecco le regole:<br></p>
+<li>Non utilizzare le applicazioni che cambiano il ID della console.<br></li>
+<li>Non utilizzare trucchi, o qualsiasi altra modifica al gioco, che forniscano vantaggi (modificatori di punteggio, di strumenti, di velocità, texture modificate, ...) nelle partite con giocatori casuali. I trucchi sono consentiti solo nella "regione 191" e nelle sfide private tra amici, <b>se l'host ne è consenziente.</b></li>
 <p></p>
 <p class="cjk">
-<b>5. Wiimmfi &amp; RiiConnect24
-si riserva il diritto di sospendere immediatamente o sospendere l'uso di Wiimmfi o RiiConnect24 per, a loro esclusiva discrezione, qualsiasi violazione del presente Codice di Comportamento Wii o di regole Wiimmfi. Tutti i divieti possono essere temporanei o permanenti. </b>
+<b>5. Wiimmfi e/o RiiConnect24
+si riservano il diritto di sospendere (temporaneamente o permanentemente) e senza preavviso l'uso di Wiimmfi o RiiConnect24 per, a loro esclusiva discrezione, qualsiasi violazione di qualsiasi punto del presente accordo.</b>
 </p>
 <FOOTER>
-		<P>Translated by GameCube</P>
+		<P>Translated by Ryccardo and GameCube</P>
 </FOOTER>
-</li></body></html>
+</body></html>
+	


### PR DESCRIPTION
Hi Larsen, as we discussed by email, here's my proposal of significantly improved translation: however...

...while doing it, I noticed several issues (with both this translation and the original, which you may want to look into before accepting it:

- Large parts of the text seem ripped off from the Nintendo original agreement and badly adapted, reading as if RC24 has a saying on the operation of Wii Shop or Nintendo on what gets done on Wiimmfi, etc - I have tried to clarify the separation but didn't completely finish the job before I get an opinion
(I have interpreted articles 1/2/most parts of 13 as related to only Nintendo's services)

- What's Wiimmfi's policy on trading game items/accounts for real money? As written now, it still literally says that Nintendo prohibits it (through a likely invalid claim that they own your saves, too) @Wiimm

- What happened to article 7?

- Article 5 is cut off and whatever it may try to imply is unclear

- Every single link in the page - whether to Nintendo's original rules (now still applicable - but only to the eShop, is the message you want to make clear?) or rc24.xyz/eula, is currently broken

- Article 13 - a very large number of definitions is redundant from the Nintendo rules, outdated (WiiConnect24, point cards, ...) and not useful for understanding the RC24/Wiimmfi rules  

